### PR TITLE
The engines line was incorrect.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "author": "Francis Gulotta <wizard@roborooter.com>",
   "name": "punycode",
   "description": "Javascript Punycode converter derived from example in RFC3492.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/reconbot/Node-PunyCode.git"
   },
-  "engines": {"npm":"1.0.6","node":"v0.4.7"},
+  "engines": {"npm":"1.0.x","node":"0.4.x"},
   "dependencies": {},
   "devDependencies": {},
   "homepage": "https://github.com/reconbot/Node-PunyCode"


### PR DESCRIPTION
Trying to install punycode with NPM v1.0.94-v1.0.100:

```
npm ERR! Unsupported
npm ERR! Not compatible with your version of node/npm: punycode@0.0.1
npm ERR! Required: {"npm":"1.0.6","node":"v0.4.7"}
npm ERR! Actual:   {"npm":"1.0.100","node":"0.4.13-pre"}
```

I've fixed that for you.  Tested with `npm install punycode@'https://github.com/goinstant/Node-PunyCode/tarball/master'`

Thanks in advance,
~jeremy
